### PR TITLE
レシピの工程と材料も登録できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ yarn run dev
 
 ```bash
 # すべてのシーダーを実行する
-yarn prisma db seed
+DB=dev yarn prisma db seed
 
 # 特定のシーダーを実行する（関数名 = キャメルケースで指定する）
-yarn prisma db seed chefSeeder
+DB=dev yarn prisma db seed chefSeeder
 ```
 
 ### APIを実行する

--- a/prisma/migrations/20230622004235_add_recipe_id_to_recipe_process/migration.sql
+++ b/prisma/migrations/20230622004235_add_recipe_id_to_recipe_process/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `recipeId` to the `RecipeProcess` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `RecipeProcess` ADD COLUMN `recipeId` VARCHAR(30) NOT NULL;
+
+-- CreateIndex
+CREATE INDEX `RecipeProcess_recipeId_idx` ON `RecipeProcess`(`recipeId`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,6 +66,8 @@ model Recipe {
   images      RecipeImage[]
   /// レシピの材料
   ingredients RecipeIngredient[]
+  /// レシピの作り方
+  processes   RecipeProcess[]
   /// レシピのリンク
   links       RecipeLink[]
 }
@@ -105,13 +107,17 @@ model RecipeImage {
 
 /// レシピの工程
 model RecipeProcess {
-  id          Int    @id @default(autoincrement())
+  id          Int     @id @default(autoincrement())
+  recipeId    String  @db.VarChar(30)
+  recipe      Recipe? @relation(fields: [recipeId], references: [id])
   /// 工程の順番
-  order       Int    @db.UnsignedInt
+  order       Int     @db.UnsignedInt
   /// 工程の内容
   title       String
   /// 工程の補足
   description String
+
+  @@index([recipeId])
 }
 
 /// レシピの材料

--- a/server/database/seeder/index.ts
+++ b/server/database/seeder/index.ts
@@ -4,7 +4,7 @@ import { recipeSeeder } from "./recipe-seeder";
 
 const databaseSeeder = {
   chefSeeder,
-  recipeSeeder
+  recipeSeeder,
 };
 
 type SeederName = keyof typeof databaseSeeder;

--- a/server/database/seeder/recipe-seeder.ts
+++ b/server/database/seeder/recipe-seeder.ts
@@ -1,31 +1,93 @@
-import { ImageResponse } from "next/server";
 import { prisma } from "../prisma";
 
+type RecipeData = {
+  name: string;
+  yields: number;
+  description: string;
+  imageId: string;
+  ingredients: string[];
+  processes: string[];
+};
+
+const recipes: RecipeData[] = [
+  {
+    name: "グラタン",
+    yields: 2,
+    description:
+      "はじめてでも失敗なく作れるような、鶏肉や玉ねぎを具とした基本的なマカロニグラタンのレシピです。ソースと具材炒めを別器具で行うレシピも多いですが、グラタンの具を炒めたフライパンの中で、そのままホワイトソースを仕上げる手軽な作り方にしています。ぜひお試しください。",
+    imageId: "recipeapp/recipeImages/RecipeImage-4_d7ooyb",
+    ingredients: ["鶏肉 200g", "玉ねぎ 1個", "油 大さじ1", "ホワイトソース 300ml", "チーズ 適量"],
+    processes: [
+      "鶏肉を適当な大きさに切ります。",
+      "玉ねぎをみじん切りにします。",
+      "フライパンに油を熱し、鶏肉を炒めます。",
+      "玉ねぎを加えて炒めます。",
+      "鶏肉と玉ねぎが煮えたら、火を止めます。",
+      "耐熱容器に鶏肉と玉ねぎを入れ、ホワイトソースを注ぎます。",
+      "表面にチーズを散らし、オーブンで焼きます。",
+      "チーズが溶けてこんがりとした色になったら、完成です。",
+    ],
+  },
+  {
+    name: "カレー",
+    yields: 4,
+    description: "スパイシーで香り豊かなカレーです。",
+    imageId: "recipeapp/recipeImages/RecipeImage-6_mid6ka",
+    ingredients: ["玉ねぎ 1個", "鶏肉 300g", "油 大さじ2", "カレールー 100g", "水 500ml", "じゃがいも 2個", "人参 1本"],
+    processes: [
+      "玉ねぎをみじん切りにします。",
+      "鍋に油を熱し、玉ねぎを炒めます。",
+      "鶏肉を加えて炒めます。",
+      "鶏肉に火が通ったら、カレールーを加えます。",
+      "水を加えて煮込みます。",
+      "じゃがいもと人参を加えて煮込みます。",
+      "具材が柔らかくなったら、火を止めます。",
+      "ご飯と一緒に盛り付けて、完成です。",
+    ],
+  },
+];
+
 export async function recipeSeeder() {
-  const chef = await prisma.chef.findFirstOrThrow()
-  // レシピを登録する
+  const chef = await prisma.chef.findFirstOrThrow();
+
   await prisma.chef.update({
     where: {
       id: chef.id,
     },
-    data:{
-      recipes:{
-        create: [
-          {
-            recipe: {
-              create: {
-                name:"グラタン",
-                yields:2,
-                description:"はじめてでも失敗なく作れるような、鶏肉や玉ねぎを具とした基本的なマカロニグラタンのレシピです。ソースと具材炒めを別器具で行うレシピも多いですが、グラタンの具を炒めたフライパンの中で、そのままホワイトソースを仕上げる手軽な作り方にしています。ぜひお試しください。",
-                images:{
-                  createMany:{
-                    data: [{ imageId: 'recipeapp/recipeImages/RecipeImage-4_d7ooyb'}]
-                  }
-                }
-              }
-          }}
-        ]
-      }
-    }
-  })
+    data: {
+      recipes: {
+        create: recipes.map((recipe) => ({
+          recipe: {
+            create: {
+              name: recipe.name,
+              yields: recipe.yields,
+              description: recipe.description,
+              images: {
+                createMany: {
+                  data: [{ imageId: recipe.imageId }],
+                },
+              },
+              ingredients: {
+                createMany: {
+                  data: recipe.ingredients.map((ingredient) => ({
+                    title: ingredient,
+                    description: "",
+                  })),
+                },
+              },
+              processes: {
+                createMany: {
+                  data: recipe.processes.map((process, index) => ({
+                    order: index + 1,
+                    title: process,
+                    description: "",
+                  })),
+                },
+              },
+            },
+          },
+        })),
+      },
+    },
+  });
 }


### PR DESCRIPTION
## PRの内容

recipeSeederで、レシピの工程と材料を登録できるようにしました。

## 補足

レシピの材料と工程は、仕様変更で単なる文字列を入力することになっていたので、titleのみデータを登録するようにしています。

参考: [アプリの仕様の変更について](https://www.notion.so/e3a69d5b4d924a55875ac3d5736dfc42)