### PR TITLE
レシピの検索機能を実装

### DIFF
--- a/server/_chef-recipe/api-schema.ts
+++ b/server/_chef-recipe/api-schema.ts
@@ -11,3 +11,5 @@ export const SearchInput = z.object({
 export const RecipeIdInput = z.object({
   recipeId: z.string(),
 });
+
+export const GetRecipesInput = SearchInput;

--- a/server/_chef-recipe/get-recipes.ts
+++ b/server/_chef-recipe/get-recipes.ts
@@ -1,6 +1,7 @@
 import { publicProcedure } from "../trpc/init-trpc";
+import { GetRecipesInput } from "./api-schema";
 
-export const getRecipes = publicProcedure.query(async ({ ctx }) => {
+export const getRecipes = publicProcedure.input(GetRecipesInput).query(async ({ ctx, input }) => {
   const recipes = await ctx.prisma.recipe.findMany({
     select: {
       id: true,
@@ -10,9 +11,12 @@ export const getRecipes = publicProcedure.query(async ({ ctx }) => {
       _count: { select: { favorites: true } },
     },
     where: {
-      chefRecipe: {
-        isNot: null,
-      },
+      chefRecipe: { isNot: null },
+      ...(input.search === undefined
+        ? {}
+        : {
+            OR: [{ name: { contains: input.search } }, { description: { contains: input.search } }],
+          }),
     },
   });
   return recipes;


### PR DESCRIPTION
## PRの内容

レシピの検索機能を実装しました。検索対象のフィールドは、レシピ名とレシピの説明です。

## 動作確認方法

Postmanなどで、検索パラメータを送信するとレシピを検索することができます。

[【小ネタ】tRPCのAPIをPostmanで実行する方法](https://zenn.dev/tekihei2317/articles/e9eb843eb728a9)

## その他連絡事項

- 検索機能のフロントエンドとの繋ぎ込みは、次のPRで実装します。
