### PR TITLE
フォローとお気に入りのAPIを作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ yarn run dev
 
 ## TIPS
 
-### シーダーを実行する
+### シーダーを実行する方法
 
 ```bash
 # すべてのシーダーを実行する
@@ -37,41 +37,16 @@ DB=dev yarn prisma db seed
 DB=dev yarn prisma db seed chefSeeder
 ```
 
-### APIを実行する
+### APIの動作確認をする方法
 
-tRPCはHTTPベースのRPCなので、curlやPostmanから実行することができます。
+tRPCはHTTPベースのRPCなので、curlやPostmanから実行することができます。APIのエンドポイントは、`localhost:3000/api/trpc/{プロシージャ名}`です。
 
-```json
-$ curl localhost:3000/api/trpc/chefs | jq .
-{
-  "result": {
-    "data": [
-      {
-        "id": "clix21kl40007u0bc0jz6jkvy",
-        "displayName": "Alexandra Dupont",
-        "bio": "フランス料理のスタイルを尊重しながら、現代的なアプローチを取るフレンチシェフ。シンプルで洗練された料理に、斬新なアイデアを取り入れた独自のメニューを提供します。フレーバーパリングのマスターとして知られ、素材の持つ個性を引き立てます。",
-        "profileImageUrl": "image_1_1_s8bktj",
-        "recipeCount": 0
-      },
-      {
-        "id": "clix21kl40005u0bcb02h50xo",
-        "displayName": "Andrea Rossi",
-        "bio": "イタリア料理の名門出身で、伝統と創造性を融合させる技術を持つシェフ。家庭的で温かみのある料理から、高級レストランでの本格的なイタリアンまで幅広いジャンルに精通しています。素材の鮮度と風味を最大限に引き出し、愛情を込めた料理を提供します。",
-        "profileImageUrl": "image_1_1_s8bktj",
-        "recipeCount": 0
-      }
-    ]
-  }
-}
-```
+実行方法の詳細は、下記のドキュメントを参照してください。
 
-`/api/trpc/chefs`の`chefs`の部分は、プロシージャの名前です。
+- [HTTP RPC Specification | tRPC](https://trpc.io/docs/v9/rpc)
+- [【小ネタ】tRPCのAPIをPostmanで実行する方法](https://zenn.dev/tekihei2317/articles/e9eb843eb728a9)
 
-パラメータを送信する場合は、mutationの場合はリクエストボディに設定します。queryの場合は`myQuery?input=${encodeURIComponent(JSON.stringify(input))`のように、エンコードしてクエリパラメータに設定します。
-
-RPCの詳細は[HTTP RPC Specification | tRPC](https://trpc.io/docs/v9/rpc)を参照してください。
-
-### PlanetScaleに対してマイグレーションを実行する
+### PlanetScaleに対してマイグレーションを実行する方法
 
 まず、PlanetScaleのコンソールからmainブランチの接続URLを取得して、.envの`DATABASE_URL`に設定します。
 

--- a/server/_follow-favorite/api-schema.ts
+++ b/server/_follow-favorite/api-schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const FollowChefInput = z.object({
+  chefId: z.string(),
+});
+
+export const FavoriteRecipeInput = z.object({
+  recipeId: z.string(),
+});

--- a/server/_follow-favorite/favorite-recipe.ts
+++ b/server/_follow-favorite/favorite-recipe.ts
@@ -1,10 +1,17 @@
+import { TRPCError } from "@trpc/server";
 import { protectedProcedure } from "../trpc/init-trpc";
 import { FavoriteRecipeInput } from "./api-schema";
+import { validateRecipeId } from "./utils";
 
 /**
  * レシピをお気に入りする
  */
 export const favoriteRecipe = protectedProcedure.input(FavoriteRecipeInput).mutation(async ({ ctx, input }) => {
+  const result = await validateRecipeId(ctx.prisma, input.recipeId);
+  if (!result.success) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "レシピIDが正しくありません" });
+  }
+
   const favorite = await ctx.prisma.favorite.findUnique({
     where: {
       userId_recipeId: {
@@ -13,12 +20,12 @@ export const favoriteRecipe = protectedProcedure.input(FavoriteRecipeInput).muta
       },
     },
   });
-  if (favorite === null) {
-    await ctx.prisma.favorite.create({
-      data: {
-        userId: ctx.user.userId,
-        recipeId: input.recipeId,
-      },
-    });
-  }
+  if (favorite !== null) return favorite;
+
+  return await ctx.prisma.favorite.create({
+    data: {
+      userId: ctx.user.userId,
+      recipeId: input.recipeId,
+    },
+  });
 });

--- a/server/_follow-favorite/favorite-recipe.ts
+++ b/server/_follow-favorite/favorite-recipe.ts
@@ -1,0 +1,24 @@
+import { protectedProcedure } from "../trpc/init-trpc";
+import { FavoriteRecipeInput } from "./api-schema";
+
+/**
+ * レシピをお気に入りする
+ */
+export const favoriteRecipe = protectedProcedure.input(FavoriteRecipeInput).mutation(async ({ ctx, input }) => {
+  const favorite = await ctx.prisma.favorite.findUnique({
+    where: {
+      userId_recipeId: {
+        userId: ctx.user.userId,
+        recipeId: input.recipeId,
+      },
+    },
+  });
+  if (favorite === null) {
+    await ctx.prisma.favorite.create({
+      data: {
+        userId: ctx.user.userId,
+        recipeId: input.recipeId,
+      },
+    });
+  }
+});

--- a/server/_follow-favorite/follow-chef.ts
+++ b/server/_follow-favorite/follow-chef.ts
@@ -1,0 +1,21 @@
+import { protectedProcedure } from "../trpc/init-trpc";
+import { FollowChefInput } from "./api-schema";
+
+/**
+ * シェフをフォローする
+ */
+export const followChef = protectedProcedure.input(FollowChefInput).mutation(async ({ ctx, input }) => {
+  await ctx.prisma.following.upsert({
+    where: {
+      userId_chefId: {
+        userId: ctx.user.userId,
+        chefId: input.chefId,
+      },
+    },
+    create: {
+      userId: ctx.user.userId,
+      chefId: input.chefId,
+    },
+    update: {},
+  });
+});

--- a/server/_follow-favorite/follow-chef.ts
+++ b/server/_follow-favorite/follow-chef.ts
@@ -1,11 +1,18 @@
+import { TRPCError } from "@trpc/server";
 import { protectedProcedure } from "../trpc/init-trpc";
 import { FollowChefInput } from "./api-schema";
+import { validateChefId } from "./utils";
 
 /**
  * シェフをフォローする
  */
 export const followChef = protectedProcedure.input(FollowChefInput).mutation(async ({ ctx, input }) => {
-  await ctx.prisma.following.upsert({
+  const result = await validateChefId(ctx.prisma, input.chefId);
+  if (!result.success) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: result.error });
+  }
+
+  const following = await ctx.prisma.following.upsert({
     where: {
       userId_chefId: {
         userId: ctx.user.userId,
@@ -18,4 +25,5 @@ export const followChef = protectedProcedure.input(FollowChefInput).mutation(asy
     },
     update: {},
   });
+  return following;
 });

--- a/server/_follow-favorite/router.ts
+++ b/server/_follow-favorite/router.ts
@@ -1,0 +1,12 @@
+import { router } from "../trpc/init-trpc";
+import { favoriteRecipe } from "./favorite-recipe";
+import { followChef } from "./follow-chef";
+import { unfavoriteRecipe } from "./unfavorite-recipe";
+import { unfollowChef } from "./unfollow-chef";
+
+export const followFavoriteRouter = router({
+  followChef,
+  unfollowChef,
+  favoriteRecipe,
+  unfavoriteRecipe,
+});

--- a/server/_follow-favorite/unfavorite-recipe.ts
+++ b/server/_follow-favorite/unfavorite-recipe.ts
@@ -1,0 +1,19 @@
+import { protectedProcedure } from "../trpc/init-trpc";
+import { FavoriteRecipeInput } from "./api-schema";
+
+/**
+ * レシピのお気に入りを解除する
+ */
+export const unfavoriteRecipe = protectedProcedure.input(FavoriteRecipeInput).mutation(async ({ ctx, input }) => {
+  const favorite = await ctx.prisma.favorite.findUnique({
+    where: {
+      userId_recipeId: {
+        userId: ctx.user.userId,
+        recipeId: input.recipeId,
+      },
+    },
+  });
+  if (favorite !== null) {
+    await ctx.prisma.favorite.delete({ where: { id: favorite.id } });
+  }
+});

--- a/server/_follow-favorite/unfollow-chef.ts
+++ b/server/_follow-favorite/unfollow-chef.ts
@@ -1,0 +1,19 @@
+import { protectedProcedure } from "../trpc/init-trpc";
+import { FollowChefInput } from "./api-schema";
+
+/**
+ * シェフのフォローを解除する
+ */
+export const unfollowChef = protectedProcedure.input(FollowChefInput).mutation(async ({ ctx, input }) => {
+  const following = await ctx.prisma.following.findUnique({
+    where: {
+      userId_chefId: {
+        chefId: input.chefId,
+        userId: ctx.user.userId,
+      },
+    },
+  });
+  if (following !== null) {
+    await ctx.prisma.following.delete({ where: { id: following.id } });
+  }
+});

--- a/server/_follow-favorite/utils.ts
+++ b/server/_follow-favorite/utils.ts
@@ -1,0 +1,22 @@
+import { PrismaClient } from "@prisma/client";
+import { Result } from "../utils/result";
+
+/**
+ * シェフIDがDBに存在する値か検証する
+ */
+export async function validateChefId(prisma: PrismaClient, chefId: string): Promise<Result<string, undefined>> {
+  if ((await prisma.chef.findUnique({ where: { id: chefId } })) === null) {
+    return Result.error(undefined);
+  }
+  return Result.ok(chefId);
+}
+
+/**
+ * レシピIDがDBに存在する値か検証する
+ */
+export async function validateRecipeId(prisma: PrismaClient, recipeId: string): Promise<Result<string, undefined>> {
+  if ((await prisma.recipe.findUnique({ where: { id: recipeId } })) === null) {
+    return Result.error(undefined);
+  }
+  return Result.ok(recipeId);
+}

--- a/server/trpc/router.ts
+++ b/server/trpc/router.ts
@@ -3,19 +3,11 @@ import { mergeRouters, publicProcedure, router } from "./init-trpc";
 import { chefRecipeRouter } from "../_chef-recipe/router";
 import { authRouter } from "../_auth/router";
 import { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
+import { followFavoriteRouter } from "../_follow-favorite/router";
 
 const healthCheck = publicProcedure.query(() => ({ status: "Running" }));
 
-const getUserCount = publicProcedure.query(async ({ ctx }) => {
-  return ctx.prisma.user.count();
-});
-
-const testRouter = router({
-  health: healthCheck,
-  userCount: getUserCount,
-});
-
-export const appRouter = mergeRouters(testRouter, chefRecipeRouter, authRouter);
+export const appRouter = mergeRouters(router({ healthCheck }), chefRecipeRouter, authRouter, followFavoriteRouter);
 
 export const trpcCaller = appRouter.createCaller({ user: undefined, prisma });
 

--- a/server/utils/result.ts
+++ b/server/utils/result.ts
@@ -1,0 +1,20 @@
+type Ok<T> = {
+  success: true;
+  value: T;
+};
+
+type Error<E> = {
+  success: false;
+  error: E;
+};
+
+export type Result<T, E> = Ok<T> | Error<E>;
+
+export const Result = {
+  ok<T>(value: T): Ok<T> {
+    return { success: true, value };
+  },
+  error<E>(error: E): Error<E> {
+    return { success: false, error };
+  },
+};


### PR DESCRIPTION
## PRの内容

フォローとお気に入りのAPIを作成しました。

## 動作確認方法

- ブラウザから、レシピアプリにログインします。
- PostmanからCookieを送信できるように、Postman Interceptor（Chromeの拡張機能）をインストールします。
  - 参考: [PostmanでCookieが必要なAPIを実行する - ユニファ開発者ブログ](https://tech.unifa-e.com/entry/2021/05/10/083532)
- Postmanで、`/api/trpc/favoriteUser`にPostでリクエストを送ります。リクエストボディは下記のような感じです。
 
```json
{
    "chefId": "clk2geeoc00075pjczk7s1lw5"
}
```

## その他連絡事項

- Prismaの外部キー制約のエミュレーションは、レコードの登録時には行われないようでした（不正な値を登録できる）
  - https://www.prisma.io/docs/concepts/components/prisma-schema/relations/relation-mode#which-foreign-key-constraints-are-emulated