### PR TITLE
お気に入り画面に必要なAPIの作成

### DIFF
--- a/server/_follow-favorite/get-favorite-recipes.ts
+++ b/server/_follow-favorite/get-favorite-recipes.ts
@@ -1,0 +1,30 @@
+import { getRecipeImageUrlFromImages } from "../_chef-recipe/recipe-util";
+import { protectedProcedure } from "../trpc/init-trpc";
+
+/**
+ * お気に入りレシピの一覧を取得する
+ */
+export const getFavoriteRecipes = protectedProcedure.query(async ({ ctx }) => {
+  const favorites = await ctx.prisma.favorite.findMany({
+    where: { userId: ctx.user.userId },
+    select: {
+      recipe: {
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          images: true,
+          _count: { select: { favorites: true } },
+        },
+      },
+    },
+    orderBy: { id: "desc" },
+  });
+  const favoriteRecipes = favorites.map(({ recipe: { _count, images, ...recipe } }) => ({
+    ...recipe,
+    imageUrl: getRecipeImageUrlFromImages(images),
+    favoriteCount: _count.favorites,
+  }));
+
+  return favoriteRecipes;
+});

--- a/server/_follow-favorite/get-following-chefs.ts
+++ b/server/_follow-favorite/get-following-chefs.ts
@@ -1,0 +1,19 @@
+import { protectedProcedure } from "../trpc/init-trpc";
+import { getImageUrl } from "../utils/cloudinary";
+
+/**
+ * フォローしているシェフの一覧を取得する
+ */
+export const getFollowingChefs = protectedProcedure.query(async ({ ctx }) => {
+  const followings = await ctx.prisma.following.findMany({
+    where: { userId: ctx.user.userId },
+    include: { chef: true },
+  });
+
+  const chefs = followings.map(({ chef }) => ({
+    id: chef.id,
+    displayName: chef.displayName,
+    profileImageUrl: getImageUrl(chef.profileImage),
+  }));
+  return chefs;
+});

--- a/server/_follow-favorite/get-new-recipes.ts
+++ b/server/_follow-favorite/get-new-recipes.ts
@@ -1,0 +1,39 @@
+import { getRecipeImageUrlFromImages } from "../_chef-recipe/recipe-util";
+import { protectedProcedure } from "../trpc/init-trpc";
+
+// TODO: 一般ユーザーもフォローできる仕様に対応する
+
+/**
+ * フォローしているシェフの新着レシピを取得する
+ */
+export const getNewRecipes = protectedProcedure.query(async ({ ctx }) => {
+  const followingChefIds = (
+    await ctx.prisma.following.findMany({
+      where: { userId: ctx.user.userId },
+      select: { chefId: true },
+    })
+  ).map(({ chefId }) => chefId);
+  const recipes = await ctx.prisma.recipe.findMany({
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      images: true,
+      _count: { select: { favorites: true } },
+    },
+    where: {
+      chefRecipe: {
+        chefId: { in: followingChefIds },
+      },
+    },
+    orderBy: { id: "desc" },
+    // TODO: 取得する件数を決める
+    take: 20,
+  });
+
+  return recipes.map(({ _count, images, ...recipe }) => ({
+    ...recipe,
+    imageUrl: getRecipeImageUrlFromImages(images),
+    favoriteCount: _count.favorites,
+  }));
+});

--- a/server/_follow-favorite/router.ts
+++ b/server/_follow-favorite/router.ts
@@ -1,6 +1,7 @@
 import { router } from "../trpc/init-trpc";
 import { favoriteRecipe } from "./favorite-recipe";
 import { followChef } from "./follow-chef";
+import { getFavoriteRecipes } from "./get-favorite-recipes";
 import { getFollowingChefs } from "./get-following-chefs";
 import { unfavoriteRecipe } from "./unfavorite-recipe";
 import { unfollowChef } from "./unfollow-chef";
@@ -11,4 +12,5 @@ export const followFavoriteRouter = router({
   favoriteRecipe,
   unfavoriteRecipe,
   followingChefs: getFollowingChefs,
+  favoriteRecipes: getFavoriteRecipes,
 });

--- a/server/_follow-favorite/router.ts
+++ b/server/_follow-favorite/router.ts
@@ -3,6 +3,7 @@ import { favoriteRecipe } from "./favorite-recipe";
 import { followChef } from "./follow-chef";
 import { getFavoriteRecipes } from "./get-favorite-recipes";
 import { getFollowingChefs } from "./get-following-chefs";
+import { getNewRecipes } from "./get-new-recipes";
 import { unfavoriteRecipe } from "./unfavorite-recipe";
 import { unfollowChef } from "./unfollow-chef";
 
@@ -13,4 +14,5 @@ export const followFavoriteRouter = router({
   unfavoriteRecipe,
   followingChefs: getFollowingChefs,
   favoriteRecipes: getFavoriteRecipes,
+  chefsNewRecipes: getNewRecipes,
 });

--- a/server/_follow-favorite/router.ts
+++ b/server/_follow-favorite/router.ts
@@ -1,6 +1,7 @@
 import { router } from "../trpc/init-trpc";
 import { favoriteRecipe } from "./favorite-recipe";
 import { followChef } from "./follow-chef";
+import { getFollowingChefs } from "./get-following-chefs";
 import { unfavoriteRecipe } from "./unfavorite-recipe";
 import { unfollowChef } from "./unfollow-chef";
 
@@ -9,4 +10,5 @@ export const followFavoriteRouter = router({
   unfollowChef,
   favoriteRecipe,
   unfavoriteRecipe,
+  followingChefs: getFollowingChefs,
 });


### PR DESCRIPTION
## PRの内容

お気に入り画面に必要なAPIを作成しました。作成したAPIは次の3つです。

- フォローしているシェフの一覧の取得
- お気に入りレシピの一覧の取得（お気に入り日時の降順）
- 新着レシピ（フォローしているシェフのレシピの新着順）の取得

## 動作確認方法

- APIにリクエストを送ると、該当するデータを取得することができます。
  - フォローしているシェフの一覧→`followingChefs`
  - お気に入りレシピの一覧→`favoriteRecipes`
  - 新着レシピの一覧→`chefsNewRecipes`

## その他連絡事項

- 悩んでいるところ、特にレビューしてほしいところなどがあれば
  - フォローしているシェフは何順で表示するのがいいのか
  - 新着レシピの最大件数はどうするのがいいのか（ひとまず20件にしました）
