### PR TITLE
開発に必要な情報をREADMEに追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@
 
 ```bash
 cp .env.example .env
+```
 
+`.env`で空欄になっている箇所は、[環境変数に設定するシークレット情報](https://www.notion.so/150cad500ab94c23bbd87c01542dae5a)の内容を入力します。
+
+```bash
 # パッケージのインストール
 yarn install
 
@@ -25,61 +29,6 @@ yarn run dev
 
 [http://localhost:3000](http://localhost:3000)でアプリケーションを確認できます。
 
-## TIPS
+## その他
 
-### シーダーを実行する方法
-
-```bash
-# すべてのシーダーを実行する
-DB=dev yarn prisma db seed
-
-# 特定のシーダーを実行する（関数名 = キャメルケースで指定する）
-DB=dev yarn prisma db seed chefSeeder
-```
-
-### APIの動作確認をする方法
-
-tRPCはHTTPベースのRPCなので、curlやPostmanから実行することができます。APIのエンドポイントは、`localhost:3000/api/trpc/{プロシージャ名}`です。
-
-実行方法の詳細は、下記のドキュメントを参照してください。
-
-- [HTTP RPC Specification | tRPC](https://trpc.io/docs/v9/rpc)
-- [【小ネタ】tRPCのAPIをPostmanで実行する方法](https://zenn.dev/tekihei2317/articles/e9eb843eb728a9)
-
-### PlanetScaleに対してマイグレーションを実行する方法
-
-まず、PlanetScaleのコンソールからmainブランチの接続URLを取得して、.envの`DATABASE_URL`に設定します。
-
-```text
-DATABASE_URL=<取得したURL>
-```
-
-設定したら、次のコマンドでマイグレーションを実行します。
-
-```bash
-yarn prisma migrate deploy
-```
-
-マイグレーションを実行したら、ローカルでの開発中に間違って接続しないように`DATABASE_URL`はコメントアウトします。
-
-ドキュメントでは、PlanetScaleに開発用のブランチを作成して、デプロイリクエストでスキーマの変更を反映する方法が推奨されています。
-
-しかし、次の理由から開発中はmainブランチに対して直接`prisma migrate deploy`を実行することにしました。
-
-- ブランチを作成してからデプロイするまでの手間がかかるため
-- ローカル開発ではDockerのMySQLコンテナを使用したかったため
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+- [server/README.md](./server/README.md)

--- a/server/README.md
+++ b/server/README.md
@@ -95,6 +95,12 @@ tRPCはHTTPベースのRPCなので、curlやPostmanから実行することが�
 - [HTTP RPC Specification | tRPC](https://trpc.io/docs/v9/rpc)
 - [【小ネタ】tRPCのAPIをPostmanで実行する方法](https://zenn.dev/tekihei2317/articles/e9eb843eb728a9)
 
+認証付きのAPIを実行する場合は、Cookieを送信する必要があります。Postmanの場合は、Chrome拡張機能のPostman Interceptorを使って、ChromeのCookieと同期できます。
+
+- https://learning.postman.com/docs/sending-requests/capturing-request-data/syncing-cookies/#syncing-cookies-with-postman-interceptor
+
+同期を有効にした後、WebアプリにログインしてからAPIにリクエストを送信します。
+
 ### PlanetScaleに対してマイグレーションを実行する方法
 
 まず、PlanetScaleのコンソールからmainブランチの接続URLを取得して、.envの`DATABASE_URL`に設定します。

--- a/server/README.md
+++ b/server/README.md
@@ -28,7 +28,7 @@ https://miro.com/app/board/o9J_laecEvw=/
 - `utils`
 - `_auth`、`_chef-recipe`、`_follow-favorite`、...
 
-`_auth`、`_chef-recipe`などの`_`から始まるディレクトリは、機能を表すディレクトリ（移行、機能ディレクトリ）です。機能の依存関係を考慮して、次のように大まかにグルーピングしています。
+`_auth`、`_chef-recipe`などの`_`から始まるディレクトリは、機能を表すディレクトリ（以降、機能ディレクトリ）です。機能の依存関係を考慮して、次のように大まかにグルーピングしています。
 
 | ディレクトリ       | 機能                             |
 | ------------------ | -------------------------------- |
@@ -54,11 +54,11 @@ server/_chef-recipe
 └── router.ts
 ```
 
-`router.ts`にはAPIのルーティング、`api-schema`にはAPIの入力のバリデーション用のzodのスキーマを書いています。
+`router.ts`にはAPIのルーティング、`api-schema`にはAPIの入力のスキーマをzodで書いています。
 
-APIエンドポイントのファイルは、`get-chefs.ts`や`get-recipes`のようなファイルです。これらのファイルには、tRPCのプロシージャを書いています。
+APIエンドポイントのファイルは、`get-chefs.ts`や`get-recipes`などのファイルです。これらのファイルにはtRPCのプロシージャを書いています。
 
-新しくAPIエンドポイントを追加する場合は、`get-*.ts`や`create-*.ts`のようなファイルを作って、tRPCのプロシージャを記述してから、`router.ts`にルーティングを追加してください。
+新しくAPIエンドポイントを追加する場合は、`get-*.ts`や`create-*.ts`のようなファイルを作って、tRPCのプロシージャを記述します。それから、`router.ts`にルーティングを追加します。
 
 ## TIPS
 
@@ -95,7 +95,7 @@ tRPCはHTTPベースのRPCなので、curlやPostmanから実行することが�
 - [HTTP RPC Specification | tRPC](https://trpc.io/docs/v9/rpc)
 - [【小ネタ】tRPCのAPIをPostmanで実行する方法](https://zenn.dev/tekihei2317/articles/e9eb843eb728a9)
 
-認証付きのAPIを実行する場合は、Cookieを送信する必要があります。Postmanの場合は、Chrome拡張機能のPostman Interceptorを使って、ChromeのCookieと同期できます。
+認証付きのAPIを実行する場合はCookieが必要です。Postmanの場合は、Chrome拡張機能のPostman Interceptorを使って、ChromeのCookieと同期できます。
 
 - https://learning.postman.com/docs/sending-requests/capturing-request-data/syncing-cookies/#syncing-cookies-with-postman-interceptor
 
@@ -117,9 +117,15 @@ yarn prisma migrate deploy
 
 マイグレーションを実行したら、ローカルでの開発中に間違って接続しないように`DATABASE_URL`はコメントアウトします。
 
+#### 補足
+
 ドキュメントでは、PlanetScaleに開発用のブランチを作成して、デプロイリクエストでスキーマの変更を反映する方法が推奨されています。
 
 しかし、次の理由から開発中はmainブランチに対して直接`prisma migrate deploy`を実行することにしました。
 
 - ブランチを作成してからデプロイするまでの手間がかかるため
 - ローカル開発ではDockerのMySQLコンテナを使用したかったため
+
+PrismaとPlanetScaleの組み合わせ方については、次の記事も参考になるかもしれません。
+
+[PlanetScaleとPrismaの組み合わせ方](https://zenn.dev/tekihei2317/articles/c52b50988b423f)

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,119 @@
+# server
+
+`server`ディレクトリには、tRPCで作成しているAPIのコードを入れています。
+
+## 主なライブラリ
+
+- tRPC
+  - https://trpc.io/docs/server/introduction
+- Prisma
+  - https://www.prisma.io/docs
+
+## データベース設計について
+
+エンティティとリレーションシップを、Miroでざっくり設計しています。
+
+https://miro.com/app/board/o9J_laecEvw=/
+
+データベース設計の経緯については、次のDicsussionにも少し書かれています。
+
+[シェフ・レシピ機能のデータベースの設計（案） · qin-team-recipe/04-recipe-app · Discussion #6](https://github.com/qin-team-recipe/04-recipe-app/discussions/6)
+
+## ディレクトリ構成について
+
+トップレベルには次のディレクトリがあります。
+
+- `trpc`
+- `database`
+- `utils`
+- `_auth`、`_chef-recipe`、`_follow-favorite`、...
+
+`_auth`、`_chef-recipe`などの`_`から始まるディレクトリは、機能を表すディレクトリ（移行、機能ディレクトリ）です。機能の依存関係を考慮して、次のように大まかにグルーピングしています。
+
+| ディレクトリ       | 機能                             |
+| ------------------ | -------------------------------- |
+| `_auth`            | 認証に関する機能                 |
+| `_chef-recipe`     | シェフとレシピに関する機能       |
+| `_follow-favorite` | フォロー・お気に入りに関する機能 |
+| `_my-recipe`       | マイレシピに関する機能           |
+| `_shopping-list`   | 買い物リストに関する機能         |
+
+### 機能ディレクトリについて
+
+機能ディレクトリは、次のような構造になっています。機能ディレクトリに共通して存在するファイルは、`router.ts`、`api-schema.ts`、APIエンドポイントのファイルの3種類です。
+
+```text
+$ tree server/_chef-recipe
+server/_chef-recipe
+├── api-schema.ts
+├── get-chef.ts
+├── get-chefs.ts
+├── get-recipe.ts
+├── get-recipes.ts
+├── recipe-util.ts
+└── router.ts
+```
+
+`router.ts`にはAPIのルーティング、`api-schema`にはAPIの入力のバリデーション用のzodのスキーマを書いています。
+
+APIエンドポイントのファイルは、`get-chefs.ts`や`get-recipes`のようなファイルです。これらのファイルには、tRPCのプロシージャを書いています。
+
+新しくAPIエンドポイントを追加する場合は、`get-*.ts`や`create-*.ts`のようなファイルを作って、tRPCのプロシージャを記述してから、`router.ts`にルーティングを追加してください。
+
+## TIPS
+
+### ブラウザでデータベースの中身を確認する方法
+
+Prisma Studioで確認できます。
+
+```bash
+DB=dev yarn prisma studio
+```
+
+### シーダーを実行する方法
+
+```bash
+# すべてのシーダーを実行する
+DB=dev yarn prisma db seed
+
+# 特定のシーダーを実行する（シーダーは、関数名 = キャメルケースで指定する）
+DB=dev yarn prisma db seed chefSeeder
+```
+
+すべてのデータを削除してシーダーを実行し直す場合は、次のコマンドを実行してください。
+
+```bash
+DB=dev yarn prisma migrate reset
+```
+
+### APIの動作確認をする方法
+
+tRPCはHTTPベースのRPCなので、curlやPostmanから実行することができます。APIのエンドポイントは、`localhost:3000/api/trpc/{プロシージャ名}`です。
+
+実行方法の詳細は、下記のドキュメントを参照してください。
+
+- [HTTP RPC Specification | tRPC](https://trpc.io/docs/v9/rpc)
+- [【小ネタ】tRPCのAPIをPostmanで実行する方法](https://zenn.dev/tekihei2317/articles/e9eb843eb728a9)
+
+### PlanetScaleに対してマイグレーションを実行する方法
+
+まず、PlanetScaleのコンソールからmainブランチの接続URLを取得して、.envの`DATABASE_URL`に設定します。
+
+```text
+DATABASE_URL=<取得したURL>
+```
+
+設定したら、次のコマンドでマイグレーションを実行します。
+
+```bash
+yarn prisma migrate deploy
+```
+
+マイグレーションを実行したら、ローカルでの開発中に間違って接続しないように`DATABASE_URL`はコメントアウトします。
+
+ドキュメントでは、PlanetScaleに開発用のブランチを作成して、デプロイリクエストでスキーマの変更を反映する方法が推奨されています。
+
+しかし、次の理由から開発中はmainブランチに対して直接`prisma migrate deploy`を実行することにしました。
+
+- ブランチを作成してからデプロイするまでの手間がかかるため
+- ローカル開発ではDockerのMySQLコンテナを使用したかったため


### PR DESCRIPTION
## PRの内容

READMEに、開発で必要そうな情報を何点か追記しました。

- `.env`で空欄にしているシークレット情報について追記しました。
- READMEのうちサーバー側の実装に関する情報は、`server/README.md`に移動しました。
- バックエンドのディレクトリ構成について書きました。
- Postmanで認証付きのAPIを実行する方法を追記しました。

## 確認方法

- READMEのリンクをたどって、`.env`に記述するシークレット情報を確認できること
- バックエンド（`server/`）のディレクトリ構成について、理解できるように書かれていること

## その他連絡事項

- 悩んでいるところ、特にレビューしてほしいところなどがあれば
