### PR TITLE
レシピの詳細画面で、材料が買い物リストに含まれている場合はカートの色を変更する

### DIFF
--- a/app/recipe/[id]/ingredients/page.tsx
+++ b/app/recipe/[id]/ingredients/page.tsx
@@ -1,6 +1,6 @@
 import CopyClipboard from "@/app/components/Parts/CopyClipboard";
-import { trpcCaller } from "@/server/trpc/router";
 import { RecipeNavigation } from "../RecipeNavigation";
+import { trpcClient } from "@/app/utils/trpc";
 
 export const metadata = {
   title: "Recipes",
@@ -9,7 +9,7 @@ export const metadata = {
 
 export default async function RecipeIngredients({ params }: { params: { id: string } }) {
   const recipeId = params.id;
-  const recipe = await trpcCaller.recipe({ recipeId });
+  const recipe = await trpcClient.recipe.query({ recipeId });
   const text = recipe.ingredients
     .map((ingredient) => {
       return `${ingredient.title} ${ingredient.description}`;
@@ -77,7 +77,11 @@ export default async function RecipeIngredients({ params }: { params: { id: stri
             <li className="relative border-b-[1px] border-border px-[16px] py-[8px]" key={ingredient.id}>
               <p className="text-title text-[14px]">{ingredient.title}</p>
               <p className="text-[10px] mt-[4px]">{ingredient.description}</p>
-              <span className="absolute top-1/2 -translate-y-1/2 right-[16px] pl-[20px] stroke-[#908E96] hover:stroke-primary hover:text-primary">
+              <span
+                className={`absolute top-1/2 -translate-y-1/2 right-[16px] pl-[20px] stroke-[#908E96] hover:cursor-pointer ${
+                  ingredient.isAddedToList ? "stroke-primary text-primary" : ""
+                }`}
+              >
                 <svg width="20" height="21" viewBox="0 0 20 21" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <g clipPath="url(#clip0_3478_253)">
                     <path

--- a/server/_chef-recipe/get-recipe.ts
+++ b/server/_chef-recipe/get-recipe.ts
@@ -1,7 +1,26 @@
+import { PrismaClient } from "@prisma/client";
 import { publicProcedure } from "../trpc/init-trpc";
 import { notFoundError } from "../trpc/trpc-error";
 import { RecipeIdInput } from "./api-schema";
 import { getRecipeImageUrlFromImages } from "./recipe-util";
+
+/**
+ * レシピの材料のうち、買い物リストに含まれるもののIDを取得する
+ */
+async function getIngredientIds(prisma: PrismaClient, userId: string, ingredientIds: number[]): Promise<number[]> {
+  // 買い物リストの材料を検索する
+  const ingredients = await prisma.shopListIngredient.findMany({
+    where: {
+      recipeIngredientId: { in: ingredientIds },
+      shopListRecipe: { userId },
+    },
+  });
+
+  return ingredients.map((ingredient) => {
+    // numberのIDで検索した結果なので、nullになることはない（TODO: アサーション）
+    return ingredient.recipeIngredientId as number;
+  });
+}
 
 /**
  * レシピの情報を取得する
@@ -41,8 +60,24 @@ export const getRecipe = publicProcedure.input(RecipeIdInput).query(async ({ ctx
           where: { userId_recipeId: { userId: ctx.user.userId, recipeId: input.recipeId } },
         })) !== null;
 
+  // 買い物リストに含まれているかのフィールドを追加する
+  const ingredientIdSet = ctx.user
+    ? new Set<number>(
+        await getIngredientIds(
+          ctx.prisma,
+          ctx.user.userId,
+          recipe.ingredients.map((ingredient) => ingredient.id)
+        )
+      )
+    : new Set<number>();
+  const ingredients = recipe.ingredients.map((ingredient) => ({
+    ...ingredient,
+    isAddedToList: ingredientIdSet.has(ingredient.id),
+  }));
+
   return {
     ...recipe,
+    ingredients,
     isFavoriting,
     primaryImageUrl: getRecipeImageUrlFromImages(recipe.images),
   };


### PR DESCRIPTION
## PRの内容

レシピの詳細画面の買い物リスト機能で、材料がすでに買い物リストに追加されているかの情報が必要なので追加しました。

https://github.com/qin-team-recipe/04-recipe-app/issues/53

## 動作確認方法

- [ ] 材料を買い物リストに追加されている場合、カートボタンの色が変わること

## その他連絡事項
