### PR TITLE
Hotfix validation of image and url

### DIFF
--- a/server/_my-recipe/api-schema.ts
+++ b/server/_my-recipe/api-schema.ts
@@ -9,9 +9,9 @@ export const createMyRecipeInput = z.object({
   ingredients: z.array(z.string()),
   yields: z.number().max(6).min(1),
   processes: z.array(z.string()),
-  images: z.array(z.string()),
+  images: z.array(z.string()).optional(),
   description: z.string().optional(),
-  urls: z.array(z.string().url()),
+  urls: z.array(z.string().url()).optional().default([]),
 });
 
 export const updateMyRecipeInput = z.object({
@@ -20,7 +20,7 @@ export const updateMyRecipeInput = z.object({
   ingredients: z.array(z.string()),
   yields: z.number().max(6).min(1),
   processes: z.array(z.string()),
-  images: z.array(z.string()),
+  images: z.array(z.string()).optional(),
   description: z.string().optional(),
-  urls: z.array(z.string().url()),
+  urls: z.array(z.string().url()).optional(),
 });

--- a/server/_my-recipe/api-schema.ts
+++ b/server/_my-recipe/api-schema.ts
@@ -11,7 +11,7 @@ export const createMyRecipeInput = z.object({
   processes: z.array(z.string()),
   images: z.array(z.string()).optional(),
   description: z.string().optional(),
-  urls: z.array(z.string().url()).optional().default([]),
+  urls: z.array(z.string().url()).optional(),
 });
 
 export const updateMyRecipeInput = z.object({

--- a/server/_my-recipe/update-my-recipe.ts
+++ b/server/_my-recipe/update-my-recipe.ts
@@ -25,7 +25,7 @@ export const updateMyRecipe = protectedProcedure.input(updateMyRecipeInput).muta
 
   // cloudinaryの画像を更新
   await Promise.all(recipe.images.map((image) => deleteImageInCloudinary(image.imageId)));
-  const publicIds = await Promise.all(input.images.map((image) => uploadImageToCloudinary(image)));
+  const publicIds = input.images ? await Promise.all(input.images.map((image) => uploadImageToCloudinary(image))) : [];
 
   // requestのJSONをもとに更新処理
   return await ctx.prisma.recipe.update({
@@ -57,7 +57,7 @@ export const updateMyRecipe = protectedProcedure.input(updateMyRecipeInput).muta
       links: {
         deleteMany: {},
         createMany: {
-          data: input.urls.map((url) => ({ url })),
+          data: (input.urls ?? []).map((url) => ({ url })),
         },
       },
     },


### PR DESCRIPTION
## PRの内容
マイレシピ登録API及びマイレシピ更新APIにて画像とURLを必須から任意に変更
## 動作確認方法
以下でマイレシピの登録を行う際にimagesとurlsが無くても登録できるようになりました。
※更新時も同様。
URI：/regmyrecipe
JSON：
{
　"name": "マイレシピ登録のレシピ名",
　"ingredients": ["鶏肉 200g", "玉ねぎ 1個", "油 大さじ1", "ホワイトソース 300ml", "チーズ 適量"],
　"yields": 4,
　"description":
　"descriptionの中身",
　"images": ["data:image/png;base64,<ここにbase64の画像データ>"],
　"processes": [
　　"鶏肉を適当な大きさに切ります。",
　　"玉ねぎをみじん切りにします。",
　　"フライパンに油を熱し、鶏肉を炒めます。",
　　"玉ねぎを加えて炒めます。",
　　"鶏肉と玉ねぎが煮えたら、火を止めます。",
　　"耐熱容器に鶏肉と玉ねぎを入れ、ホワイトソースを注ぎます。",
　　"表面にチーズを散らし、オーブンで焼きます。",
　　"チーズが溶けてこんがりとした色になったら、完成です。"
　],
　"urls":[]
}
## その他連絡事項

- 画像を複数送れる（配列で複数送る）機能はどちらにも対応できるためそのままにしています。

